### PR TITLE
#46 Added configurable limit no file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/nginx-role/tree/develop)
+### Added
+- *[#46](https://github.com/idealista/nginx-role/issues/46) Added configurable limit no file* @javierRobledo, @danieljesus
 
 ## [1.7.0](https://github.com/idealista/nginx-role/tree/1.7.0) (2018-2-23)
 [Full Changelog](https://github.com/idealista/nginx-role/compare/1.6.0...1.7.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,3 +68,5 @@ nginx_compile_time_options_builtin_modules:
 nginx_compile_time_options_external_modules_paths:
   - "{{ nginx_src_dir }}/headers-more-nginx-module-{{ headers_more_version }}"
   - "{{ nginx_src_dir }}/lua-nginx-module-{{ lua_module_version }}"
+
+nginx_limit_no_file: 1024

--- a/templates/nginx.service.j2
+++ b/templates/nginx.service.j2
@@ -12,6 +12,7 @@ ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s QUIT $MAINPID
 PrivateTmp=true
 User=root
+LimitNOFILE={{ nginx_limit_no_file }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Requirements

* No any new requirements, set in defaults.

### Description of the Change

Added Nginx service LimitNOFILE option with a default value of 1024.


### Benefits

Now you can override default LimitNOFILE if your nginx creates lots of files.

### Possible Drawbacks

It's only a configuration. It shouldn't have any drawback.


### Applicable Issues

https://github.com/idealista/nginx-role/issues/46