### PR TITLE
Add system:true to create nginx_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 - *Add goss test to check nginx_user UId have system range of uids* @adrian-arapiles
 ### Fixed
 - *Fix indent for goss http test of nginx metrics prometheus* @adrian-arapiles
+- *[#57](https://github.com/idealista/nginx_role/issues/57) Disable create home for user nginx.*
 
 ## [2.1.1](https://github.com/idealista/nginx_role/tree/2.1.1) (2019-10-19)
 [Full Changelog](https://github.com/idealista/nginx_role/compare/2.1.1...2.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/nginx_role/tree/develop)
+### Added
+- *Add system:true on create nginx_user to avoid get UID on system range* @adrian-arapiles
+- *Add goss test to check nginx_user UId have system range of uids* @adrian-arapiles
+### Fixed
+- *Fix indent for goss http test of nginx metrics prometheus* @adrian-arapiles
 
 ## [2.1.1](https://github.com/idealista/nginx_role/tree/2.1.1) (2019-10-19)
 [Full Changelog](https://github.com/idealista/nginx_role/compare/2.1.1...2.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/nginx_role/tree/develop)
 ### Added
-- *Add system:true on create nginx_user to avoid get UID on system range* @adrian-arapiles
+- *Add system:true on create nginx_user to get UID on system range* @adrian-arapiles
 - *Add goss test to check nginx_user UId have system range of uids* @adrian-arapiles
 ### Fixed
 - *Fix indent for goss http test of nginx metrics prometheus* @adrian-arapiles

--- a/molecule/default/tests/test_nginx.yml
+++ b/molecule/default/tests/test_nginx.yml
@@ -7,6 +7,8 @@ group:
 user:
   {{ nginx_user }}:
     exists: true
+    uid:
+      lt: 1000
     groups:
       - {{ nginx_group }}
 
@@ -57,5 +59,5 @@ port:
     listening: true
 
 http:
-http://localhost:{{ nginx_prometheus_metrics_port }}/{{ nginx_prometheus_metrics_path }}:
-  status: 200
+  http://localhost:{{ nginx_prometheus_metrics_port }}/{{ nginx_prometheus_metrics_path }}:
+    status: 200

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -3,6 +3,7 @@
   user:
     name: "{{ nginx_user }}"
     groups: "{{ nginx_groups|join(',') }}"
+    system: true
     append: true
 
 - name: NGINX | Create log directory

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,6 +5,7 @@
     groups: "{{ nginx_groups|join(',') }}"
     system: true
     append: true
+    create_home: false
 
 - name: NGINX | Create log directory
   file:


### PR DESCRIPTION
### Description of the Change
### Added
- *Add system:true on create nginx_user to get UID on system range* @adrian-arapiles
- *Add goss test to check nginx_user UId have system range of uids* @adrian-arapiles
### Fixed
- *Fix indent for goss http test of nginx metrics prometheus* @adrian-arapiles
- *[#57](https://github.com/idealista/nginx_role/issues/57) Disable create home for user nginx.*

### Benefits
- Avoid conflict of uids with nominal users.
### Possible Drawbacks
- Not change with users already created, it only works for new users created.
<!-- What are the possible side-effects or negative impacts of the code change? -->
None side-effects that i know of.