### PR TITLE
85: Use get_url instead of unarchive to have timeout configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/nginx_role/tree/develop)
+### Added
+- *[#85](https://github.com/idealista/nginx_role/issues/85) Use get_url instead of unarchive to have timeout configuration* @jperera
+
 [Full Changelog](https://github.com/idealista/nginx_role/compare/3.2.0...3.3.0)
 ## [3.3.0](https://github.com/idealista/nginx_role/tree/3.3.0) (2020-09-17)
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Nginx: 1.14.* + lua_module_version: 0.10.13
 
 ```
 $ pipenv sync
-$ MOLECULE_DISTRO=(jessie|stretch|buster) pipenv run molecule test
+$ MOLECULE_DISTRO=(debian:jessie-slim|debian:stretch-slim|debian:buster-slim) pipenv run molecule test
 ```
 
-Note: Debian9 (Debian Stretch) will be used as default linux distro if none is provided.
+Note: Debian10 (Debian Buster) will be used as default linux distro if none is provided.
 
 See [molecule.yml](https://github.com/idealista/rsyslog_role/blob/master/molecule/default/molecule.yml) to check possible testing platforms.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ nginx_url: http://nginx.org/download/nginx-{{ nginx_version }}.tar.gz
 
 # Files & Paths
 nginx_download_dir: "/tmp"
+nginx_download_timeout: 20
 nginx_src_dir: "/usr/src"
 nginx_log_path: "/var/log/nginx"
 nginx_access_log: "{{ nginx_log_path }}/access.log"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -13,13 +13,23 @@
   ignore_errors: true
 
 - name: NGINX | Download luaJIT
-  unarchive:
-    copy: false
-    src: "{{ luaJIT_url }}"
+  get_url:
+    url: "{{ luaJIT_url }}"
     dest: "{{ nginx_download_dir }}"
+    timeout: "{{ nginx_download_timeout }}"
   when: nginx_force_reinstall or
-        luaJIT_check is failed or
-        "LuaJIT " + luaJIT_version[:3] not in luaJIT_check.stdout
+    luaJIT_check is failed or
+    "LuaJIT " + luaJIT_version[:3] not in luaJIT_check.stdout
+  register: nginx_downloaded_lua_jit_path
+
+- name: NGINX | Decompress luaJIT
+  unarchive:
+    src: "{{ nginx_downloaded_lua_jit_path.dest }}"
+    dest: "{{ nginx_download_dir }}"
+    remote_src: true
+  when: nginx_force_reinstall or
+    luaJIT_check is failed or
+    "LuaJIT " + luaJIT_version[:3] not in luaJIT_check.stdout
 
 - name: NGINX | Build luaJIT
   make:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,15 +11,26 @@
   changed_when: false
   ignore_errors: true
 
-- name: NGINX | Get external module
-  unarchive:
-    copy: false
-    src: "{{ item.url }}"
-    dest: "{{ nginx_src_dir }}"
+- name: NGINX | Download external modules
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ nginx_download_dir }}"
+    timeout: "{{ nginx_download_timeout }}"
   loop: "{{ nginx_external_modules }}"
   when: nginx_force_reinstall or
-        nginx_check is failed or
-        "nginx/" + nginx_version not in nginx_check.stderr
+    nginx_check is failed or
+    "nginx/" + nginx_version not in nginx_check.stderr
+  register: nginx_external_modules_paths
+
+- name: NGINX | Decompress external modules
+  unarchive:
+    copy: false
+    src: "{{ item.dest }}"
+    dest: "{{ nginx_src_dir }}"
+  loop: "{{ nginx_external_modules_paths.results }}"
+  when: nginx_force_reinstall or
+    nginx_check is failed or
+    "nginx/" + nginx_version not in nginx_check.stderr
 
 - name: NGINX | Untar nginx
   unarchive:

--- a/tasks/metrics.yml
+++ b/tasks/metrics.yml
@@ -1,7 +1,15 @@
 ---
-- name: NGINX | Get nginx-lua-prometheus
+
+- name: NGINX | Download nginx-lua-prometheus
+  get_url:
+    url: "{{ nginx_lua_prometheus_url }}"
+    dest: "{{ nginx_download_dir }}"
+    timeout: "{{ nginx_download_timeout }}"
+  register: nginx_downloaded_lua_prometheus_path
+
+- name: NGINX | Decompress nginx-lua-prometheus
   unarchive:
-    src: "{{ nginx_lua_prometheus_url }}"
+    src: "{{ nginx_downloaded_lua_prometheus_path.dest }}"
     dest: "{{ nginx_download_dir }}"
     remote_src: true
 
@@ -9,9 +17,9 @@
   copy:
     src: "{{ nginx_download_dir }}/nginx-lua-prometheus-{{ nginx_lua_prometheus_version }}/prometheus.lua"
     dest: "{{ nginx_conf_path }}/plugins/prometheus.lua"
-    remote_src: true
     owner: "{{ nginx_user }}"
     group: "{{ nginx_group }}"
+    remote_src: true
 
 - name: NGINX | Copy prometheus metric server conf
   template:


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

You are able to configure timeout downloading dependecies.

### Possible Drawbacks

The time to fail with actual connection problem increase.

### Applicable Issues

https://github.com/idealista/nginx_role/issues/85
