### PR TITLE
#98 Use nginx_group as group and parametrized shell to the user

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.yml linguist-detectable=true
+*.yaml linguist-detectable=true
+*.html linguist-detectable=false
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/nginx_role/tree/develop)
+### Fixed
+- *[#98](https://github.com/idealista/nginx_role/issues/98) Fix nginx_group not set as primary group* @caldito
 
 ## [3.5.1](https://github.com/idealista/nginx_role/tree/3.5.1) (2021-03-01)
 ### Fixed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ nginx_user: nginx
 nginx_group: nginx
 nginx_groups: []
 
+# Shell
+nginx_shell: /usr/sbin/nologin
+
 # start on boot
 nginx_service_enabled: true
 # current state: started, stopped

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,10 +1,18 @@
 ---
+
+- name: NGINX | Ensure nginx group
+  group:
+    name: "{{ nginx_group }}"
+    system: true
+    state: present
+
 - name: NGINX | Configuring user groups
   user:
     name: "{{ nginx_user }}"
+    group: "{{ nginx_group }}"
     groups: "{{ nginx_groups|join(',') }}"
     system: true
-    append: true
+    shell: "{{ nginx_shell }}"
     create_home: false
 
 - name: NGINX | Create log directory


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
Fix bug that made that `nginx_group` variable did not set the primary group. And also added parametrized shell to the user, with the default value as `/usr/sbin/nologin`, which is the same as most of our roles.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits
Group bug fixed and also added the shell parameter like in the rest of our roles, but also parametrized it in case it needs to change.

### Possible Drawbacks
None
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
#98
<!-- Enter any applicable Issues here -->
