### PR TITLE
[111] Fix old server deletion task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/nginx_role/tree/develop)
+### Fixed
+- *[#111](https://github.com/idealista/nginx_role/issues/111) Fixed deletion of old server files configuration* @xtianae7
 
 ## [4.2.0](https://github.com/idealista/nginx_role/tree/4.2.0) (2022-06-22)
 [Full Changelog](https://github.com/idealista/nginx_role/compare/4.1.0...4.2.0)

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -138,7 +138,7 @@
   file:
     path: "{{ nginx_conf_path }}/sites-enabled/{{ item }}"
     state: absent
-  loop:
+  with_items:
     - "{{ all_servers_available.files | map(attribute='path') |  map('basename') | list | difference(nginx_available_servers) }}"
   notify: reload nginx
 
@@ -146,7 +146,7 @@
   file:
     path: "{{ nginx_conf_path }}/sites-available/{{ item }}"
     state: absent
-  loop:
+  with_items:
     - "{{ all_servers_available.files | map(attribute='path') |  map('basename') | list | difference(nginx_available_servers) }}"
 
 - name: NGINX | Enable servers templates


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Fix the behavior of deletion tasks of old servers.

Basically, this is what was happening: https://italchemy.wordpress.com/2021/07/23/ansible-with_items-vs-loop-whats-the-difference/

### Benefits

<!-- What benefits will be realized by the code change? -->
Bugfix. The role will do its intended behavior

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
If someone was using this role and was accidentally working with a server configuration that is no longer in the playbook, on their next execution, that server configuration will be deleted.

### Applicable Issues

<!-- Enter any applicable Issues here -->
Closes #111 
